### PR TITLE
Use not instead of {True: False, False: True}

### DIFF
--- a/discord/voice_client.py
+++ b/discord/voice_client.py
@@ -777,7 +777,7 @@ class VoiceClient(VoiceProtocol):
          """
         if not self.recording:
             raise ClientException("Not currently recording audio.")
-        self.paused = {True: False, False: True}[self.paused]
+        self.paused = not self.paused
 
     def continue_recv(self):
         # If data is not received while not recording

--- a/examples/receive_vc_audio.py
+++ b/examples/receive_vc_audio.py
@@ -110,7 +110,7 @@ class Client(discord.Client):
     @vc_required
     async def pause_recording(self, msg, vc):
         vc.pause_recording()
-        await msg.channel.send("The recording has been " + {True: "paused!", False: 'unpaused!'}[vc.paused])
+        await msg.channel.send("The recording has been " + "paused" if vc.paused else "resumed" + "!")
 
     @vc_required
     async def stop_recording(self, msg, vc):


### PR DESCRIPTION
## Summary

You can use `not self.paused` instead of `{True: False, False: True}[self.paused]`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
